### PR TITLE
remove abort if phptimeseries datafile size appears incorrect.

### DIFF
--- a/backup/lib/phptimeseries.php
+++ b/backup/lib/phptimeseries.php
@@ -9,7 +9,7 @@ function import_phptimeseries($feedid,$server,$apikey,$datadir)
 
         if (intval($downloadfrom/9.0)!=($downloadfrom/9.0)) { 
             echo "PHPTimeSeries: local datafile filesize is not an integer number of 9 bytes\n"; 
-            return false;
+//            return false;
         }
         
     } else {


### PR DESCRIPTION
For some reason this trips up with a file size of 6309b

First run failed to copy a phptimeseries feed because "local datafile filesize is not an integer number of 9 bytes" and a 2nd run confirmed the same error

```
PHPFINA: 12345
--downloaded: 0 bytes
PHPTimeSeries: local datafile filesize is not an integer number of 9 bytes
PHPFINA: 12347
--downloaded: 0 bytes
```

Couldn't find anything wrong with the source feed so I commented out the "return false" and got the following

```
PHPFINA: 12345
--downloaded: 0 bytes
PHPTimeSeries: local datafile filesize is not an integer number of 9 bytes
PHPTIMESERIES: 12346
--downloaded: 6309 bytes
PHPFINA: 12347
--downloaded: 0 bytes
```

My calculator says 6309 / 9 = 701 exactly!

This was just a quick and dirty fix, noted here so it can get resolved or hopefully to avoid other users wasting time trying to find why certain files are not copied.

(All feed ids fudged)  